### PR TITLE
Remove component-emitter dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "component-emitter": "^1.2.0",
     "array-flatten": "^2.0.0",
     "object-assign": "^4.0.1",
     "is-plain-object": "^2.0.1"

--- a/test/bibimbap.js
+++ b/test/bibimbap.js
@@ -143,7 +143,7 @@ describe('Bibimbap', function() {
         var state = new Bibimbap({
           test: 'original'
         });
-        state.on('commit', function(tree, prev, cursor) {
+        state.subscribe(function(tree, prev, cursor) {
           assert.equal('hello', tree.test);
           assert.equal('hello', cursor.get());
           assert.equal('original', prev.test);
@@ -156,7 +156,7 @@ describe('Bibimbap', function() {
         var state = new Bibimbap({
           test: 'original'
         });
-        state.on('commit', function(tree, prev, cursor) {
+        state.subscribe(function(tree, prev, cursor) {
           assert.equal('second', tree.test);
           assert.equal('second', cursor.get());
           assert.equal('original', prev.test);


### PR DESCRIPTION
Removes the [component-emitter](https://github.com/component/emitter) dependency and replaces it with a built-in list of listeners. 

## Reasons

- Reduce the build size
- Emitter was used for just a single event type

## API changes (breaking)

Previous:
```js
const state = new Bibimbap();
function onCommit(tree, prev, cursor) {
  // stuff
}
state.on('commit', onCommit);
state.off('commit', onCommit);
```

New:
```js
const state = new Bibimbap();
const unsubscribe = state.subscribe((tree, prev, cursor) => {
  // stuff
});
unsubscribe();
```